### PR TITLE
Update email addresses for Pete Birley

### DIFF
--- a/default_data.json
+++ b/default_data.json
@@ -22359,7 +22359,7 @@
                 }
             ],
             "user_name": "portdirect",
-            "emails": ["pete@port.direct", "pete.birley@att.com"]
+            "emails": ["pete@port.direct", "pete.birley@att.com", "pb269f@att.com", "petebirley@gmail.com", "petebirley@googlemail.com" ]
         },
         {
             "launchpad_id": "powerds0111",


### PR DESCRIPTION
This commit updates the email addresses for Pete Birley's commits.

Signed-off-by: Pete Birley <pete@port.direct>