### PR TITLE
restore istio.github.io

### DIFF
--- a/default_data.json
+++ b/default_data.json
@@ -38510,6 +38510,11 @@
             "uri": "https://github.com/istio/proxy.git"
         },
         {
+            "module": "istio.github.io",
+            "organization": "istio",
+            "uri": "https://github.com/istio/istio.github.io.git"
+        },
+        {
             "module": "istio.io@istio",
             "organization": "istio",
             "uri": "https://github.com/istio/istio.io.git"


### PR DESCRIPTION
https://github.com/istio/istio.github.io.git  has been rename to https://github.com/istio/istio.io.git, when delete istio.github.io, old PRs are lost.