### PR TITLE
Add domain inmotionhosting.com - InMotion Hosting

### DIFF
--- a/default_data.json
+++ b/default_data.json
@@ -35553,6 +35553,10 @@
             "company_name": "InMon"
         },
         {
+            "domains": ["inmotionhosting.com"],
+            "company_name": "InMotion Hosting"
+        },
+        {
             "domains": ["inria.fr"],
             "company_name": "Inria",
             "aliases": ["INRIA"]


### PR DESCRIPTION
I am an authorized OpenStack corporate contributor for InMotion Hosting. I would like to add our domain - inmotionhosting.com - to the list of domains so that our contributors can associate their contributions they have made on behalf our company with our company name.