### PR TITLE
Add Linkerd 2 repository

### DIFF
--- a/default_data.json
+++ b/default_data.json
@@ -40678,6 +40678,11 @@
             "organization": "Linkerd"
         },
         {
+            "module": "linkerd2",
+            "uri": "https://github.com/linkerd/linkerd2.git",
+            "organization": "Linkerd"
+        },
+        {
             "module": "helm",
             "uri": "https://github.com/helm/helm.git",
             "organization": "Helm"


### PR DESCRIPTION
Linkerd 2 is not currently being tracked. It is a CNCF incubating project https://www.cncf.io/projects/

/cc @niksv 