### PR TITLE
Change City Network company name to Cleura

### DIFF
--- a/default_data.json
+++ b/default_data.json
@@ -38552,8 +38552,9 @@
             "company_name": "Citrix"
         },
         {
-            "domains": ["citynetwork.se", "citynetwork.eu", "citycloud.com"],
-            "company_name": "City Network"
+            "domains": ["cleura.com", "cleura.cloud", "citynetwork.se", "citynetwork.eu", "citycloud.com"],
+            "company_name": "Cleura",
+            "aliases": ["City Network"]
         },
         {
             "domains": ["clear-code.com"],


### PR DESCRIPTION
With rebranding [1] of City Network to Cleura, we updating company
name and adding old one as an alias.
Cleura domains are also being added to the list.

[1] https://cleura.com/press-releases/city-network-becomes-cleura/