### PR TITLE
Walt boring

### DIFF
--- a/default_data.json
+++ b/default_data.json
@@ -33652,7 +33652,7 @@
                 },
                 {
                     "company_name": "SUSE",
-                    "end_date": "2019-Oct-1"
+                    "end_date": "2019-Oct-01"
                 },
                 {
                     "company_name": "SAP",

--- a/default_data.json
+++ b/default_data.json
@@ -33652,13 +33652,17 @@
                 },
                 {
                     "company_name": "SUSE",
-                    "end_date": null
+                    "end_date": "2019-Oct-1"
+                },
+                {
+                    "company_name": "SAP",
+                    "end_data": null
                 }
             ],
             "user_name": "Walter A. Boring IV",
             "emails": [
                 "waboring@hemna.com", "walter.a.boring@ibm.com", "walter.boring@hp.com", "walter.boring@hpe.com",
-                "wboring@suse.com"
+                "wboring@suse.com", "walter.boring.iv@sap.com"
             ]
         },
         {


### PR DESCRIPTION
Try and fix my stackalytics company reference.  SUSE has an end date and has had one for a while.
Yet my stats are still showing up as SUSE, not SAP.

SUSE long ago ditched OpenStack and fired their whole OpenStack team.